### PR TITLE
Don't restore point when auto saving

### DIFF
--- a/real-auto-save.el
+++ b/real-auto-save.el
@@ -77,7 +77,7 @@
 (defun real-auto-save-buffers ()
   "Automatically save all buffers in real-auto-save-buffers-list."
   (progn
-    (save-excursion
+    (save-current-buffer
       (dolist (elem real-auto-save-buffers-list)
         (if (get-buffer elem)
             (progn


### PR DESCRIPTION
We are not changing point so we only need to save and restore the current buffer. Restoring the point can be annoying if you have save-hook functions that change the point.