### PR TITLE
Add `autoload' magic keyword to `real-auto-save-mode'.

### DIFF
--- a/real-auto-save.el
+++ b/real-auto-save.el
@@ -98,6 +98,7 @@
       (setq real-auto-save-buffers-list
             (delete (current-buffer) real-auto-save-buffers-list))))
 
+;;;###autoload
 (define-minor-mode real-auto-save-mode
   "Save your buffers automatically."
   :lighter " RAS"


### PR DESCRIPTION
Hi. Although this package is very good, I fixed it because an error occurred during use.

```
(use-package real-auto-save :defer t
  (add-hook 'find-file-hook 'real-auto-save-mode))
```
Then open file will cause below error.

```
Debugger entered--Lisp error: (void-function real-auto-save-mode)
  real-auto-save-mode()
  run-hooks(find-file-hook)
  after-find-file(nil t)
  ...
```

This error occurs because the autoload flag is not set so I add it.