### PR TITLE
Remove mentioning real-auto-save-use-idle-timer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ For example, to use this mode only for org files, add this to your Emacs config:
 
 By default, real-auto-save mode uses idle timer. If your emacs is idle, after `real-auto-save-interval` seconds it will save buffers.
 
-If you want to save all your buffers, every `real-auto-save-interval` seconds, irrespective of idle time, use
-
-    (setq real-auto-save-use-idle-timer nil)
-
+If you want to save all your buffers, every `real-auto-save-interval` seconds.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Remove mentioning `real-auto-save-use-idle-timer` config.
This issue reported at issue #52.