### PR TITLE
add global-real-auto-save-mode

### DIFF
--- a/real-auto-save.el
+++ b/real-auto-save.el
@@ -102,11 +102,12 @@ If RESTART is non-nil, restart timer."
         (delq (current-buffer) real-auto-save-buffers-list)))
 
 (defun real-auto-save-turn-on ()
-  "Turn on Real-Auto-Save Mode.
+  "Turn on Real-Auto-Save Mode for current if it's visiting a file.
 
 This function is designed to be added to hooks, for example:
   (add-hook \\='c-mode-hook #\\='real-auto-save-turn-turn-on)"
-  (real-auto-save-mode 1))
+  (when buffer-file-name
+    (real-auto-save-mode +1))
 
 (defun real-auto-save-turn-off ()
   "Turn off Real-Auto-Save Mode.

--- a/real-auto-save.el
+++ b/real-auto-save.el
@@ -101,6 +101,7 @@ If RESTART is non-nil, restart timer."
   (setq real-auto-save-buffers-list
         (delq (current-buffer) real-auto-save-buffers-list)))
 
+;;;###autoload
 (defun real-auto-save-turn-on ()
   "Turn on Real-Auto-Save Mode for current if it's visiting a file.
 
@@ -109,6 +110,7 @@ This function is designed to be added to hooks, for example:
   (when buffer-file-name
     (real-auto-save-mode +1))
 
+;;;###autoload
 (defun real-auto-save-turn-off ()
   "Turn off Real-Auto-Save Mode.
 

--- a/real-auto-save.el
+++ b/real-auto-save.el
@@ -101,6 +101,9 @@ If RESTART is non-nil, restart timer."
   (setq real-auto-save-buffers-list
         (delq (current-buffer) real-auto-save-buffers-list)))
 
+(defun turn-on-real-auto-save () (real-auto-save-mode 1))
+(defun turn-off-real-auto-save () (real-auto-save-mode -1))
+
 ;;;###autoload
 (define-minor-mode real-auto-save-mode
   "Save your buffers automatically."
@@ -109,6 +112,10 @@ If RESTART is non-nil, restart timer."
   (if real-auto-save-mode
       (real-auto-save--setup)
     (real-auto-save--teardown)))
+
+;;;###autoload
+(define-globalized-minor-mode global-real-auto-save-mode
+  real-auto-save-mode turn-on-real-auto-save)
 
 (provide 'real-auto-save)
 ;;; real-auto-save.el ends here

--- a/real-auto-save.el
+++ b/real-auto-save.el
@@ -101,8 +101,22 @@ If RESTART is non-nil, restart timer."
   (setq real-auto-save-buffers-list
         (delq (current-buffer) real-auto-save-buffers-list)))
 
-(defun turn-on-real-auto-save () (real-auto-save-mode 1))
-(defun turn-off-real-auto-save () (real-auto-save-mode -1))
+(defun real-auto-save-turn-on ()
+  "Turn on Real-Auto-Save Mode.
+
+This function is designed to be added to hooks, for example:
+  (add-hook \\='c-mode-hook #\\='real-auto-save-turn-turn-on)"
+  (real-auto-save-mode 1))
+
+(defun real-auto-save-turn-off ()
+  "Turn off Real-Auto-Save Mode.
+
+This function is designed to be added to hooks, for example:
+  (add-hook \\='message-mode-hook #\\='real-auto-save-turn-off)
+
+Useful in combination when `global-real-auto-save-mode' is used to
+opt-out of auto-saving on a per-buffer or per-mode basis."
+    (real-auto-save-mode -1))
 
 ;;;###autoload
 (define-minor-mode real-auto-save-mode
@@ -115,7 +129,7 @@ If RESTART is non-nil, restart timer."
 
 ;;;###autoload
 (define-globalized-minor-mode global-real-auto-save-mode
-  real-auto-save-mode turn-on-real-auto-save)
+  real-auto-save-mode real-auto-save-turn-on)
 
 (provide 'real-auto-save)
 ;;; real-auto-save.el ends here


### PR DESCRIPTION
I'm not an experiences Emacs package developer, so a review and feedback would be much appreciated!

With the global mode enabled, one can disable `real-auto-save-mode` on a per-buffer or per-major-mode basis. I found this easier for my setup than enabling auto saving for every conceivable mode.

I tested it this way:

```
;; init.el
(require 'real-auto-save)
(setq real-auto-save-interval 10) ;; in seconds
(defun turn-on-real-auto-save () (real-auto-save-mode 1))
(defun turn-off-real-auto-save () (real-auto-save-mode -1))
(define-globalized-minor-mode global-real-auto-save-mode
  real-auto-save-mode turn-on-real-auto-save)
(global-real-auto-save-mode 1)
(add-hook 'message-mode-hook #'turn-off-real-auto-save)
```

Auto-saving in .txt files works, auto-saving in message drafts is disabled. Manually disabling this in a buffer via `M-: (real-auto-save-mode -1)` works, too, and doesn't affect the next file you visit (i.e. auto-saving is still enabled by default).